### PR TITLE
25 tester le UI localement avec lapi distante

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,4 @@ save-tree: ## Enregistre l'arborescence du projet dans le fichier arborescence.t
 	@echo "Arborescence enregistrée dans le fichier arborescence.txt"
 
 dev-react:  ## Lance l'interface React en mode développement via npm
-	@echo "Démarrage de l'API FastAPI..."
-	. .venv-api-embedding/bin/activate && uvicorn api.main:app --reload & \
-	( \
-		echo "Attente que l'API FastAPI soit prête..." && \
-		for i in {1..30}; do \
-			curl -s http://127.0.0.1:8000/health && break || sleep 1; \
-		done; \
-	)
-	@echo "Démarrage de l'application React..."
 	cd ui/ && npm run dev

--- a/ui/.env
+++ b/ui/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=https://embedding-api-rsfvo.ondigitalocean.app/search
+VITE_API_URL=https://embedding-api-rsfvo.ondigitalocean.app

--- a/ui/.env
+++ b/ui/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://embedding-api-rsfvo.ondigitalocean.app/search

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -11,7 +11,7 @@ function App() {
   const getSearchResults = async () => {
     setError(null)
     try {
-      const res = await fetch('http://localhost:8000/search', {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/search`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ query: text, top_k: 5 }),
@@ -32,7 +32,7 @@ function App() {
         const [survey_id, variable_id] = id.split("::")
         return { survey_id, variable_id }
       })
-      const res = await fetch("http://localhost:8000/viz", {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/viz`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ items: payload })


### PR DESCRIPTION
CLOSES #25 

This pull request includes updates to streamline the development process and enable the use of a production API endpoint. The most notable changes involve removing the FastAPI server startup process from the `Makefile`, configuring the React app to use an environment variable for the API URL, and updating API calls in the React application to use this variable.

### Development process updates:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L29-L37): Removed the steps to start the FastAPI server in the `dev-react` target, simplifying the development workflow. React development now assumes the API is hosted externally.

### API endpoint configuration:
* [`ui/.env`](diffhunk://#diff-8637480e9ad6061e08c4112a21aa1b1949a922729ad8966e0c0b42311a64b7a4R1): Added a new environment variable, `VITE_API_URL`, pointing to the production API endpoint.

### React application updates:
* [`ui/src/App.jsx`](diffhunk://#diff-c06bc7ac8728c49d45026be83269675e4988e70014cfd7559fe39a3937c12570L14-R14): Updated API calls in the `getSearchResults` and visualization-related functions to use the `VITE_API_URL` environment variable instead of hardcoding the localhost URL. This ensures the React app dynamically uses the configured API endpoint. [[1]](diffhunk://#diff-c06bc7ac8728c49d45026be83269675e4988e70014cfd7559fe39a3937c12570L14-R14) [[2]](diffhunk://#diff-c06bc7ac8728c49d45026be83269675e4988e70014cfd7559fe39a3937c12570L35-R35)